### PR TITLE
refactor: Satisfy Dry::Struct warning about a non-frozen Hash

### DIFF
--- a/lib/translator_text/types/translation_result.rb
+++ b/lib/translator_text/types/translation_result.rb
@@ -8,7 +8,7 @@ module TranslatorText
       transform_keys(&:to_sym)
 
       attribute :translations, Types::Array.of(Translation)
-      attribute :detectedLanguage, Types::Hash.default({})
+      attribute :detectedLanguage, Types::Hash.default({}.freeze)
 
       # Returns the detected language
       #


### PR DESCRIPTION
A Dry::Struct warning shows up when using the gem:

```ruby
> require 'translator-text'
# > [dry-types] {} is mutable. Be careful: types will return the same instance of the default value every time. Call `.freeze` when setting the default or pass `shared: true` to discard this warning.
```

This changes satisfies this complaint.